### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -6,7 +6,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: app.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs12.x
       CodeUri: src/
       Description: Pinpoint-Lex-Bot AWS Lambda function.
       MemorySize: 128

--- a/template.yaml
+++ b/template.yaml
@@ -6,7 +6,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: app.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       CodeUri: src/
       Description: Pinpoint-Lex-Bot AWS Lambda function.
       MemorySize: 128


### PR DESCRIPTION
CloudFormation templates in amazon-pinpoint-lex-bot have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.